### PR TITLE
prefer UBX over NMEA when both are supported

### DIFF
--- a/radio/src/gps.cpp
+++ b/radio/src/gps.cpp
@@ -106,6 +106,7 @@ static void autodetectProtocol(uint8_t c)
 {
   static tmr10ms_t time;
   static uint8_t state = 0;
+  static tmr10ms_t firstPacketNMEA = 0;
 
   switch (state)  {
     case 0: // Init
@@ -113,7 +114,12 @@ static void autodetectProtocol(uint8_t c)
       state = 1;
     case 1: // Wait for a valid packet
       if (gpsNewFrameNMEA(c)) {
-        gpsProtocol = GPS_PROTOCOL_NMEA;
+        if (!firstPacketNMEA) {
+          firstPacketNMEA = time;
+        } else if (time - firstPacketNMEA > 200) {
+          // continuous stream of NMEA packets for 2 seconds, but no UBX packets
+          gpsProtocol = GPS_PROTOCOL_NMEA;
+        }
         state = 0;
         return;
       }
@@ -125,8 +131,9 @@ static void autodetectProtocol(uint8_t c)
       }
 
       uint32_t new_time = get_tmr10ms();
-      if (new_time - time > 20)  {
+      if (new_time - time > 50)  {
         // No message received
+        firstPacketNMEA = 0;
         changeBaudrate();
         time = new_time;
       }

--- a/radio/src/gps_ubx.cpp
+++ b/radio/src/gps_ubx.cpp
@@ -129,10 +129,7 @@ static void configureGps(bool detect)
 {
   static int state = 0;
 
-  if (detect) {
-    state = 0;
-    return;
-  }
+  if (detect) state = 0;
 
   auto txCompleted = gpsSerialDrv->txCompleted;
   if (txCompleted && !txCompleted(gpsSerialCtx)) return;


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Summary of changes: When NMEA messages are received (i.e. the baud rate is correct), the handset waits for up to 2 seconds to receive a valid UBX packet. When there are no UBX packets within a 2 second period, NMEA is selected.
